### PR TITLE
Add read + write from VInt

### DIFF
--- a/src/Tedd.SpanUtils.Tests/Span/ReadWriteTests.cs
+++ b/src/Tedd.SpanUtils.Tests/Span/ReadWriteTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using Xunit;
-using Tedd;
 
 namespace Tedd.SpanUtils.Tests.Span
 {
@@ -233,17 +232,17 @@ namespace Tedd.SpanUtils.Tests.Span
                 switch (sr)
                 {
                     case 0:
-                        a = (UInt32) rnd.Next(0, 0b00111111);
+                        a = (UInt32)rnd.Next(0, 0b00111111);
                         break;
                     case 1:
-                        a = (UInt32) rnd.Next(0b01000000, 0b00111111_11111111);
+                        a = (UInt32)rnd.Next(0b01000000, 0b00111111_11111111);
                         break;
                     case 2:
-                        a = (UInt32) rnd.Next(0b01000000_00000000, 0b00111111_11111111_11111111);
+                        a = (UInt32)rnd.Next(0b01000000_00000000, 0b00111111_11111111_11111111);
                         break;
                     //case 3:
                     default:
-                        a = (UInt32) rnd.Next(0b01000000_00000000_00000000, 0b00111111_11111111_11111111_11111111);
+                        a = (UInt32)rnd.Next(0b01000000_00000000_00000000, 0b00111111_11111111_11111111_11111111);
                         break;
                 }
 
@@ -737,6 +736,31 @@ namespace Tedd.SpanUtils.Tests.Span
                 });
 
             }
+        }
+        #endregion
+
+        #region VInt
+        [Theory]
+        [InlineData(new byte[] { 0x80 }, 1, 0x80ul, 0)]
+        [InlineData(new byte[] { 0x81 }, 1, 0x81ul, 1)]
+        [InlineData(new byte[] { 0xfe }, 1, 0xfeul, 126)]
+        [InlineData(new byte[] { 0x40, 0x7f }, 2, 0x407ful, 127)]
+        [InlineData(new byte[] { 0x40, 0x80 }, 2, 0x4080ul, 128)]
+        [InlineData(new byte[] { 0x10, 0xDE, 0xFF, 0xAD }, 4, 0x10deffad, 0xdeffad)]
+
+        public void TestVInt(byte[] bytes, int expectedLength, ulong expectedEncodedValue, ulong expectedValue)
+        {
+            var readResult = bytes.AsSpan().ReadVInt(4);
+
+            Assert.Equal(expectedLength, readResult.Length);
+            Assert.Equal(expectedEncodedValue, readResult.EncodedValue);
+            Assert.Equal(expectedValue, readResult.Value);
+
+            var writeSpan = new byte[VInt.GetSize(expectedValue)].AsSpan();
+            var writeLength = writeSpan.WriteVInt(expectedValue);
+
+            Assert.Equal(expectedLength, writeLength);
+            Assert.Equal(bytes, writeSpan.ToArray());
         }
         #endregion
     }

--- a/src/Tedd.SpanUtils/SpanWrite.cs
+++ b/src/Tedd.SpanUtils/SpanWrite.cs
@@ -89,7 +89,7 @@ namespace Tedd
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe byte Write(this Span<byte> span, char value)
         {
-            Span<char> a = stackalloc char[1] {value};
+            Span<char> a = stackalloc char[1] { value };
             var ab = MemoryMarshal.Cast<char, byte>(a);
             ab.CopyTo(span);
             return sizeof(char);
@@ -242,7 +242,7 @@ namespace Tedd
         public static byte MeasureWriteSize(this Span<byte> span, UInt32 value) => value.MeasureWriteSize();
         #endregion
 
-
+        #region VLQ
         public static byte WriteVLQ(this Span<byte> span, Int16 value)
         {
             byte i = 0;
@@ -384,7 +384,26 @@ namespace Tedd
             span[i++] = (byte)value;
             return i;
         }
+        #endregion VLQ
 
+        #region VInt
+        /// <summary>
+		/// Writes a VInt (EBML Variable Length Integer) to the specified span.
+		/// </summary>
+		/// <returns>The number of bytes written.</returns>
+		public static int WriteVInt(this Span<byte> span, ulong value)
+        {
+            int position = 0;
+            int size = VInt.GetSize(value);
 
+            value |= 1UL << (7 * size);
+            for (int i = size - 1; i >= 0; --i)
+            {
+                span[position++] = (byte)(value >> (8 * i));
+            }
+
+            return position;
+        }
+        #endregion
     }
 }

--- a/src/Tedd.SpanUtils/VInt.cs
+++ b/src/Tedd.SpanUtils/VInt.cs
@@ -1,0 +1,45 @@
+﻿namespace Tedd
+{
+    public readonly struct VInt
+	{
+		public readonly int Length;
+		public readonly ulong EncodedValue;
+		public readonly ulong Value;
+		public readonly int Size;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VInt"/> struct.
+        /// </summary>
+        /// <param name="length">The length.</param>
+        /// <param name="encoded">The encoded.</param>
+        /// <param name="value">The value.</param>
+        public VInt(int length, ulong encoded, ulong value)
+		{
+			Length = length;
+			EncodedValue = encoded;
+			Value = value;
+			Size = GetSize(Value);
+		}
+
+        /// <summary>
+        /// Returns the length of the VInt encoding for the specified value.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns>The length</returns>
+        public static int GetSize(ulong value)
+		{
+			int octets = 1;
+			while ((value + 1) >> octets * 7 != 0)
+			{
+				++octets;
+			}
+
+			return octets;
+		}
+
+		public override string ToString()
+		{
+			return $"VInt, value = {Value}, length = {Length}, encoded = {EncodedValue:X}";
+		}
+	}
+}


### PR DESCRIPTION
- ReadOnlySpan extension methods not yet updated. (BTW : why do we need to define these also? Span / ReadOnlySpan are automatically cast ?
- SpanStream also not yet updated, but I think this can be done easy once the VInt logic is approved/validated