### PR TITLE
🔧 Forge: NuGet Dependency and Framework Modernization

### DIFF
--- a/.jules/forge.md
+++ b/.jules/forge.md
@@ -1,0 +1,5 @@
+## 2025-02-18 - Tedd.SpanUtils Dependency and Framework Drift
+
+**Observation:** `System.Runtime.CompilerServices.Unsafe` (5.0.0) is marked as deprecated for legacy frameworks. `System.Memory` is outdated (4.5.4 vs 4.6.0). Internal projects (`Benchmark`, `SourceGenerator`) use `net5.0` which is unsupported (NETSDK1138). Test projects contain a deprecated reference to `Microsoft.NETCore.App` (2.2.8) alongside outdated xUnit frameworks that block modernization. Build fails due to a `System.Memory` package downgrade in `Tedd.SpanUtils.DotNet4Tests`.
+
+**Strategic Action:** Update `System.Memory` to `4.6.0` and `System.Runtime.CompilerServices.Unsafe` to `6.1.0` with proper conditional item groups. Remove deprecated `Microsoft.NETCore.App`. Update test dependencies to latest stable versions. Migrate internal tooling projects from `net5.0` to `net8.0`. Ensure local builds and packaging succeed without compatibility downgrade errors.

--- a/src/Tedd.SpanUtils.Benchmark/Tedd.SpanUtils.Benchmark.csproj
+++ b/src/Tedd.SpanUtils.Benchmark/Tedd.SpanUtils.Benchmark.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.12" />
   </ItemGroup>
 
 </Project>

--- a/src/Tedd.SpanUtils.DotNet4Tests/Tedd.SpanUtils.DotNet4Tests.csproj
+++ b/src/Tedd.SpanUtils.DotNet4Tests/Tedd.SpanUtils.DotNet4Tests.csproj
@@ -8,10 +8,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="Tedd.RandomUtils" Version="1.0.5" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1">
+    <PackageReference Include="System.Memory" Version="4.6.0" />
+    <PackageReference Include="Tedd.RandomUtils" Version="1.0.6" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Tedd.SpanUtils.SourceGenerator/Tedd.SpanUtils.SourceGenerator.csproj
+++ b/src/Tedd.SpanUtils.SourceGenerator/Tedd.SpanUtils.SourceGenerator.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Tedd.SpanUtils.Tests/Tedd.SpanUtils.Tests.csproj
+++ b/src/Tedd.SpanUtils.Tests/Tedd.SpanUtils.Tests.csproj
@@ -7,19 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="Tedd.RandomUtils" Version="1.0.5" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Tedd.RandomUtils" Version="1.0.6" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.1">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Tedd.SpanUtils/Tedd.SpanUtils.csproj
+++ b/src/Tedd.SpanUtils/Tedd.SpanUtils.csproj
@@ -22,13 +22,13 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-      <PackageReference Include="System.Memory" Version="4.5.4" />
+      <PackageReference Include="System.Memory" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard2.0'))">
-      <PackageReference Include="System.Memory" Version="4.5.4" />
+      <PackageReference Include="System.Memory" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch('$(TargetFramework)', '^(net4|netcoreapp2|netstandard)'))">
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- 💡 **Target:** Core `Tedd.SpanUtils` package dependencies, test project packages, tool target frameworks (Benchmark/SourceGenerator).
- 🎯 **Execution:** `System.Memory` updated to `4.6.0` and `System.Runtime.CompilerServices.Unsafe` to `6.1.0` in `Tedd.SpanUtils.csproj`. Outdated frameworks (`net5.0`) in tool projects migrated to `net8.0`. xUnit, BenchmarkDotNet, and Roslyn CodeAnalysis dependencies upgraded to stable versions verified via the NuGet flatcontainer API.
- 📊 **Compatibility Impact:** Multi-targeting (`net462`, `netstandard2.0`, `netstandard2.1`, `net8.0`, `net10.0`) remains intact. Older consumer compatibility preserved.
- 🔬 **Verification Protocol:** `dotnet build`, `dotnet test`, `dotnet pack`, and `dotnet format` executed across `src/Tedd.SpanUtils.sln`. Tests pass successfully.
- 📦 **NuGet Package Validation:** Explored `Tedd.SpanUtils.1.1.0-beta.7.nupkg` via `unzip -p`. Dependency groups verified as strictly partitioned per target framework without leakage.
- ⚠️ **Breaking-Change Assessment:** SemVer Patch/Minor. Modernization only bumps dependency constraints; no public API surface changes were made.

---
*PR created automatically by Jules for task [5371295483690275410](https://jules.google.com/task/5371295483690275410) started by @tedd*